### PR TITLE
Add assertIn method for Python 2.6 compatability

### DIFF
--- a/balancer/tests.py
+++ b/balancer/tests.py
@@ -39,6 +39,10 @@ class BalancerTestCase(TestCase):
         settings.MASTER_DATABASE = self.original_master
         settings.DATABASE_POOL = self.original_pool
 
+    def assertIn(self, test_value, expected_set):
+        msg = "%s did not occur in %s" % (test_value, expected_set)
+        self.assert_(test_value in expected_set, msg)
+
 
 class RandomRouterTestCase(BalancerTestCase):
 


### PR DESCRIPTION
I was hoping to help work on this package, but the assertIn method was failing on Python 2.6 / Django 1.2.5
