### PR TITLE
Fix travis builds and update setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: python
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.4
+  - 3.5
+  - 3.6
 env:
-  - DJANGO_VERSION=1.4.20
-  - DJANGO_VERSION=1.5.12
-  - DJANGO_VERSION=1.6.11
-  - DJANGO_VERSION=1.7.8
-  - DJANGO_VERSION=1.8.2
-matrix:
-  exclude:
-    - python: 2.6
-      env: DJANGO_VERSION=1.7.8
-    - python: 2.6
-      env: DJANGO_VERSION=1.8.2
-    - python: 3.4
-      env: DJANGO_VERSION=1.4.20
+  - DJANGO_VERSION=1.8.18
+  - DJANGO_VERSION=1.9.13
+  - DJANGO_VERSION=1.10.7
+  - DJANGO_VERSION=1.11.1
 install:
   - pip install -q Django==$DJANGO_VERSION
   - pip install -r test_requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from codecs import open as codecs_open
 import os
 import sys
 
@@ -11,17 +12,15 @@ except ImportError:
 
 VERSION = __import__('balancer').__version__
 
-try:
-    long_description = open('README.rst', 'rt').read()
-except IOError:
-    long_description = ''
+with codecs_open(('README.rst'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-description = 'A set of tools for using Django\'s multi-db feature to balance '\
-              'database requests'
+description = 'A set of tools for using Django\'s multi-db feature to balance' \
+              ' database requests'
 
 setup(
     name='django-balancer',
@@ -50,5 +49,6 @@ setup(
         'Topic :: Database',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English'
-    ]
+    ],
+    keywords='database pooling mysql db balancer'
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import sys
@@ -19,22 +20,35 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-description = "A set of tools for using Django's multi-db feature to balance "
-description += "database requests"
+description = 'A set of tools for using Django\'s multi-db feature to balance '\
+              'database requests'
 
 setup(
     name='django-balancer',
     version=VERSION,
     description=description,
-    long_description = long_description,
+    long_description=long_description,
     author='Brandon Konkle, Mike Helmick',
     author_email='mike@drund.com',
-    license='License :: OSI Approved :: BSD License',
-    url='http://github.com/michaelhelmick/django-balancer',
+    license='BSD License',
+    url='https://github.com/michaelhelmick/django-balancer',
     packages=['balancer'],
     classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'Development Status :: 3 - Alpha',
+        'Topic :: Database',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English'
     ]
 )


### PR DESCRIPTION
The goal of this PR is to resolve the travis build failures and update the setup.py with classifiers, keywords, some compatibility changes, and random cleanup.

In this PR, I've updated package support for Django >= 1.8.x and python 2.7, 3.5, and 3.6 only.